### PR TITLE
Initial project setup (tooling, linting, tests, ci)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: 20
+
+jobs:
+  lint-build-unit:
+    name: Lint, build, unit/dom tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - name: Install
+        run: npm ci
+
+      - name: Lint( no warnings allowed on ci)
+        run: npm run lint:ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Unit/DOM tests (Vitest)
+        run: npm run test
+
+      - name: Upload coverage report
+        if: always() && hashFiles('coverage/**') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html
+          path: coverage
+          retention-days: 7
+  e2e:
+    name: Playwright E2E
+    needs: lint-build-unit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node ${{ env.NODE_VERSION }} (with npm cache)
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Install playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: always() && hashFiles('playwright-report/**') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          retention-days: 7
+
+      - name: Upload Playwright traces
+        if: always() && hashFiles('test-results/**') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: |
+            test-results
+            playwright-report/data/*trace*.zip
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,24 @@ jobs:
             test-results
             playwright-report/data/*trace*.zip
           retention-days: 7
+  release:
+    name: Semantic Release
+    needs: [lint-build-unit, e2e]
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - name: Install
-        run: npm ci
+        run: npm install && npm ci
 
       - name: Lint( no warnings allowed on ci)
         run: npm run lint:ci
@@ -60,7 +60,7 @@ jobs:
           cache: npm
 
       - name: Install
-        run: npm ci
+        run: npm install && npm ci
 
       - name: Install playwright browsers
         run: npx playwright install --with-deps
@@ -102,7 +102,7 @@ jobs:
         with:
           node-version: 20
           cache: npm
-      - run: npm ci
+      - run: npm install && npm ci
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
-.dist
+dist
 .vscode
+playwright-report 
+test-results

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist
 .vscode
 playwright-report 
 test-results
+package-lock.json
+coverage

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+npx --yes commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,16 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    ["@semantic-release/changelog", { "changelogFile": "CHANGELOG.md" }],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md", "package.json"],
+        "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+export default { extends: ['@commitlint/config-conventional'] };

--- a/index.html
+++ b/index.html
@@ -1,1 +1,6 @@
-<!doctype html><html><body><script type="module" src="/src/main.js"></script></body></html>
+<!doctype html>
+<html>
+  <body>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,1 @@
+<!doctype html><html><body><script type="module" src="/src/main.js"></script></body></html>

--- a/package.json
+++ b/package.json
@@ -1,33 +1,78 @@
 {
   "name": "physiologydata",
   "version": "1.0.0",
+  "private": true,
   "description": "A simple web-based tool to help researchers and educators analyze **physiology simulation data**.   It transforms Excel spreadsheets into clear, interactive charts for easier insight generation and communication.",
   "main": "index.js",
   "scripts": {
-    "test": "vitest run",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
     "format": "prettier --write .",
     "lint": "eslint .",
     "lint:ci": "eslint . --max-warnings 0",
+    "test": "vitest run",
     "test:watch": "vitest",
-    "preflight": "npm run format && npm run lint:ci && npm run build && npm run test && npm run test:e2e",
+    "coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "e2e:preview": "start-server-and-test 'vite preview' http://localhost:4173 'playwright test'",
+    "e2e:dev": "start-server-and-test 'vite' http://localhost:5173 'playwright test'",
+    "prepare": "husky",
+    "preflight": "npm run format && npm run lint:ci && npm run build && npm run test && npm run test:e2e",
+    "release": "semantic-release"
   },
-  "keywords": [],
-  "author": "",
+  "lint-staged": {
+    "*.{js,ts,css,md,json}": [
+      "prettier --write"
+    ],
+    "*.{js,ts}": [
+      "eslint --fix"
+    ]
+  },
+  "keywords": [
+    "physiology",
+    "charts",
+    "xlsx",
+    "research"
+  ],
   "license": "ISC",
+  "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/medic-code/physiologydata"
+  },
+  "bugs": {
+    "url": "https://github.com/medic-code/physiologydata/issues"
+  },
+  "homepage": "https://github.com/medic-code/physiologydata#readme",
+  "engines": {
+    "node": ">=20"
+  },
+  "packageManager": "npm@10",
+  "browserList": [
+    "defualts",
+    "not dead",
+    "not op_mini all"
+  ],
   "devDependencies": {
+    "@commitlint/cli": "^19.8.1",
+    "@commitlint/config-conventional": "^19.8.1",
     "@eslint/js": "^9.33.0",
     "@playwright/test": "^1.54.2",
+    "@semantic-release/changelog": "^6.0.3",
+    "@semantic-release/git": "^10.0.1",
+    "@semantic-release/github": "^11.0.4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/user-event": "^14.6.1",
+    "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.33.0",
     "globals": "^16.3.0",
     "happy-dom": "^18.0.1",
+    "husky": "^9.1.7",
     "prettier": "^3.6.2",
+    "semantic-release": "^24.2.7",
+    "start-server-and-test": "^2.0.13",
     "vite": "^7.1.2",
     "vitest": "^3.2.4"
   },

--- a/package.json
+++ b/package.json
@@ -2,25 +2,32 @@
   "name": "physiologydata",
   "version": "1.0.0",
   "private": true,
-  "description": "A simple web-based tool to help researchers and educators analyze **physiology simulation data**.   It transforms Excel spreadsheets into clear, interactive charts for easier insight generation and communication.",
-  "main": "index.js",
+  "description": "A simple web-based tool to help researchers and educators analyze physiology simulation data.   It transforms Excel spreadsheets into clear, interactive charts for easier insight generation and communication.",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:clean": "npm run clean && npm run build",
     "preview": "vite preview",
     "format": "prettier --write .",
+    "clean": "rimraf dist coverage .vite",
+    "clean:e2e": "rimraf playwright-report test-results",
+    "clean:all": "npm run clean && npm run clean:e2e",
     "lint": "eslint .",
     "lint:ci": "eslint . --max-warnings 0",
     "test": "vitest run",
+    "test:clean": "npm run clean && npm run test",
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "e2e:preview": "start-server-and-test 'vite preview' http://localhost:4173 'playwright test'",
-    "e2e:dev": "start-server-and-test 'vite' http://localhost:5173 'playwright test'",
+    "pw:report": "playwright show-report",
+    "e2e:preview": "start-server-and-test \"vite preview\" http://localhost:4173 \"playwright test\"",
+    "e2e:preview:clean": "npm run clean:e2e && npm run e2e:preview",
+    "e2e:dev": "start-server-and-test \"vite\" http://localhost:5173 \"playwright test\"",
     "prepare": "husky",
-    "preflight": "npm run format && npm run lint:ci && npm run build && npm run test && npm run test:e2e",
-    "release": "semantic-release"
+    "preflight": "npm run format && npm run lint:ci && npm run build:clean && npm run test && npm run e2e:preview",
+    "release": "semantic-release",
+    "release:dry": "semantic-release --dry-run"
   },
   "lint-staged": {
     "*.{js,ts,css,md,json}": [
@@ -37,7 +44,7 @@
     "research"
   ],
   "license": "ISC",
-  "author": "",
+  "author": "Aaron Smith",
   "repository": {
     "type": "git",
     "url": "https://github.com/medic-code/physiologydata"
@@ -50,8 +57,8 @@
     "node": ">=20"
   },
   "packageManager": "npm@10",
-  "browserList": [
-    "defualts",
+  "browsersList": [
+    "defaults",
     "not dead",
     "not op_mini all"
   ],
@@ -64,13 +71,16 @@
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^11.0.4",
     "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.7.0",
     "@testing-library/user-event": "^14.6.1",
     "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.33.0",
+    "eslint-config-prettier": "^10.1.8",
     "globals": "^16.3.0",
     "happy-dom": "^18.0.1",
     "husky": "^9.1.7",
     "prettier": "^3.6.2",
+    "rimraf": "^6.0.1",
     "semantic-release": "^24.2.7",
     "start-server-and-test": "^2.0.13",
     "vite": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "lint": "eslint .",
     "lint:ci": "eslint . --max-warnings 0",
     "test:watch": "vitest",
-    "preflight": "npm run format && npm run lint:ci && npm run build && npm run test && npm run test:e2e"
+    "preflight": "npm run format && npm run lint:ci && npm run build && npm run test && npm run test:e2e",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "keywords": [],
   "author": "",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+    testDir: 'tests/e2e',
+    retries: 0,
+    use: {
+        trace: 'on-first-retry', // collect trace if a test retries
+        screenshot: 'only-on-failure',
+        video: 'retain-on-failure',
+        baseURL: process.env.E2E_BASE_URL || 'http://localhost:4173', // vite preview default
+    },
+    reporter: [
+        ['list'],
+        ['html', { open: 'never' }]
+    ],
+});

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,16 +1,19 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-    testDir: 'tests/e2e',
-    retries: 0,
-    use: {
-        trace: 'on-first-retry', // collect trace if a test retries
-        screenshot: 'only-on-failure',
-        video: 'retain-on-failure',
-        baseURL: process.env.E2E_BASE_URL || 'http://localhost:4173', // vite preview default
-    },
-    reporter: [
-        ['list'],
-        ['html', { open: 'never' }]
-    ],
+  testDir: 'tests/e2e',
+  retries: 0,
+  use: {
+    trace: 'on-first-retry', // collect trace if a test retries
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    baseURL: process.env.E2E_BASE_URL || 'http://localhost:4173', // vite preview default
+  },
+  webServer: {
+    command: 'npm run build && vite preview --port 4173 --strictPort',
+    url: 'http://localhost:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+  reporter: [['list'], ['html', { open: 'never' }]],
 });

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,1 @@
+console.log("hello");

--- a/src/main.js
+++ b/src/main.js
@@ -1,1 +1,1 @@
-console.log("hello");
+console.log('hello');

--- a/tests/e2e/sample.spec.js
+++ b/tests/e2e/sample.spec.js
@@ -1,1 +1,7 @@
 /* write e2e specs here */
+import { test, expect } from '@playwright/test';
+
+test('app boots', async({ page, baseURL }) => {
+    await page.goto(baseURL);
+    // Adjust the selector to something you know will exist
+});

--- a/tests/e2e/sample.spec.js
+++ b/tests/e2e/sample.spec.js
@@ -1,7 +1,6 @@
 /* write e2e specs here */
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 
 test('app boots', async({ page, baseURL }) => {
     await page.goto(baseURL);
-    // Adjust the selector to something you know will exist
 });

--- a/tests/e2e/sample.spec.js
+++ b/tests/e2e/sample.spec.js
@@ -1,0 +1,1 @@
+/* write e2e specs here */

--- a/tests/e2e/sample.spec.js
+++ b/tests/e2e/sample.spec.js
@@ -1,6 +1,6 @@
 /* write e2e specs here */
 import { test } from '@playwright/test';
 
-test('app boots', async({ page, baseURL }) => {
-    await page.goto(baseURL);
+test('app boots', async ({ page, baseURL }) => {
+  await page.goto(baseURL);
 });

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,1 @@
+/* place shared test setup here */

--- a/tests/unit/smoke.spec.js
+++ b/tests/unit/smoke.spec.js
@@ -1,0 +1,2 @@
+import { describe, it, expect } from 'vitest'; 
+describe('smoke', () => { it('runs', () => { expect(1+1).toBe(2) }) })

--- a/tests/unit/smoke.spec.js
+++ b/tests/unit/smoke.spec.js
@@ -1,2 +1,6 @@
-import { describe, it, expect } from 'vitest'; 
-describe('smoke', () => { it('runs', () => { expect(1+1).toBe(2) }) })
+import { describe, it, expect } from 'vitest';
+describe('smoke', () => {
+  it('runs', () => {
+    expect(1 + 1).toBe(2);
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,15 +1,15 @@
 import { defineConfig, configDefaults } from 'vitest/config';
 
 export default defineConfig({
-    test: {
-        globals: true,
-        environment: 'happy-dom',
-        include: ['tests/unit/**/*.spec.js', 'tests/dom/**/*.spec.js'],
-        exclude: [...configDefaults.exclude, 'tests/e2e/**'],
-        setupFiles: './tests/setup.js',
-        converage: {
-            provider: 'v8',
-            reports: ['text', 'html'],
-        },
+  test: {
+    globals: true,
+    environment: 'happy-dom',
+    include: ['tests/unit/**/*.spec.js', 'tests/dom/**/*.spec.js'],
+    exclude: [...configDefaults.exclude, 'tests/e2e/**'],
+    setupFiles: './tests/setup.js',
+    converage: {
+      provider: 'v8',
+      reports: ['text', 'html'],
     },
+  },
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,15 +1,15 @@
 import { defineConfig, configDefaults } from 'vitest/config';
 
 export default defineConfig({
-  test: {
-    globals: true,
-    environment: 'happy-dom',
-    include: ['tests/unit/**/*.spec.js', 'test/dom/**/*.spec.js'],
-    exclude: [...configDefaults.exclude, 'tests/e2e/**'],
-    setupFiles: './tests/setup.js',
-    converage: {
-      provider: 'v8',
-      reports: ['text', 'html'],
+    test: {
+        globals: true,
+        environment: 'happy-dom',
+        include: ['tests/unit/**/*.spec.js', 'tests/dom/**/*.spec.js', 'tests/e2e/**/*.spec.js'],
+        exclude: [...configDefaults.exclude, 'tests/e2e/**'],
+        setupFiles: './tests/setup.js',
+        converage: {
+            provider: 'v8',
+            reports: ['text', 'html'],
+        },
     },
-  },
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -4,7 +4,7 @@ export default defineConfig({
     test: {
         globals: true,
         environment: 'happy-dom',
-        include: ['tests/unit/**/*.spec.js', 'tests/dom/**/*.spec.js', 'tests/e2e/**/*.spec.js'],
+        include: ['tests/unit/**/*.spec.js', 'tests/dom/**/*.spec.js'],
         exclude: [...configDefaults.exclude, 'tests/e2e/**'],
         setupFiles: './tests/setup.js',
         converage: {


### PR DESCRIPTION
## Summary
Initial scaffolding of the project with tooling and CI.

## Changes
- Added Vite for dev/build
- Configured ESLint (flat config) + Prettier
- Setup Vitest + Testing Library + Playwright
- Added GitHub Actions workflow (lint, build, unit, e2e)
- Added .editorconfig, PR/Issue templates

## How to test
- Run `npm run dev` → verify local dev server
- Run `npm run lint`, `npm run test`, `npm run test:e2e` → all pass
- Check GitHub Actions on this PR → CI green
- See Vercel preview → renders placeholder app

## Checklist
- [x] CI green
- [x] Vercel preview deployed
- [x] Lint/test commands documented